### PR TITLE
implement basic UI mocks

### DIFF
--- a/dwebble/src/main.rs
+++ b/dwebble/src/main.rs
@@ -24,12 +24,22 @@ struct LoginForm {
     input: String,
 }
 
-struct LoginContext {}
+#[derive(Serialize)]
+struct LoginContext {
+    flash: String,
+    error: bool,
+}
 
 /// A very basic Template Context
 #[derive(Serialize)]
 struct HelloContext {
     name: String,
+}
+
+#[derive(Serialize)]
+struct IndexContext {
+    name: String,
+    staff_schedules: Vec<String>,
 }
 
 /// Route that demonstrates using a basic Tera Template + dynamic segment data.
@@ -50,7 +60,13 @@ fn login(
     mut cookies: Cookies,
     state: State<DwebbleConfig>,
 ) -> Template {
-    unimplemented!()
+    Template::render(
+        "login",
+        &LoginContext {
+            flash: "".to_string(),
+            error: false,
+        },
+    )
 }
 
 /// POST login form data, attempt at login attempt.
@@ -78,10 +94,18 @@ fn get_schedules() -> String {
 
 #[get("/")]
 fn index() -> Template {
+    let staff = vec![
+        "hare".to_string(),
+        "bingham".to_string(),
+        "mitchell".to_string(),
+        "xu".to_string(),
+    ];
+
     Template::render(
         "index",
-        &HelloContext {
+        &IndexContext {
             name: String::from("Anonymous User"),
+            staff_schedules: staff,
         },
     )
 }
@@ -99,8 +123,11 @@ fn main() {
         get_schedules
     ];
 
+    let cfg = RwLock::new(AppConfig {});
+
     rocket::ignite()
         .attach(Template::fairing())
         .mount("/", app_routes)
+        .manage(cfg)
         .launch();
 }

--- a/dwebble/templates/base.html.tera
+++ b/dwebble/templates/base.html.tera
@@ -7,7 +7,7 @@
         {% endif %}
     </head>
     <body>
-        <div>Hermitblog:
+        <div>Dwebble:
             <a href="/">Home</a>
             <a href="/login">Login</a>
         </div>

--- a/dwebble/templates/base.html.tera
+++ b/dwebble/templates/base.html.tera
@@ -1,0 +1,18 @@
+<html>
+    <head>
+        {% if title %}
+            <title>{{ title }} - Dwebble</title>
+        {% else %}
+            <title>Dwebble Class Scheduler</title>
+        {% endif %}
+    </head>
+    <body>
+        <div>Hermitblog:
+            <a href="/">Home</a>
+            <a href="/login">Login</a>
+        </div>
+        <hr>
+        {% block content %}
+        {% endblock content %}
+    </body>
+</html>

--- a/dwebble/templates/index.html.tera
+++ b/dwebble/templates/index.html.tera
@@ -2,4 +2,15 @@
 
 {% block content %}
     <h1>hello, {{ name }}!</h1>
+
+    {%- if staff_schedules -%}
+        <h2>staff schedules</h2>
+        <div>
+            <ul>
+                {%- for staff in staff_schedules -%}
+                    <li>{{ staff }}</li>
+                {%- endfor -%}
+            </ul>
+        </div>
+    {%- endif -%}
 {% endblock content %}

--- a/dwebble/templates/index.html.tera
+++ b/dwebble/templates/index.html.tera
@@ -1,10 +1,5 @@
-<html>
-    <head>
-        <title>welcome to dwebble!!!!</title>
-    </head>
-    <body>
-        <div>dwebble web app</div>
-        <hr>
-        <h1>hello, {{ name }}!</h1>
-    </body>
-</html>
+{% extends "base" %}
+
+{% block content %}
+    <h1>hello, {{ name }}!</h1>
+{% endblock content %}

--- a/dwebble/templates/login.html.tera
+++ b/dwebble/templates/login.html.tera
@@ -1,0 +1,36 @@
+{% extends "base" %}
+
+{% block content %}
+    {% if flash %}
+        <p><strong>{{ flash }}</strong></p>
+    {% endif %}
+    <h1>sign in</h1>
+    <form action="/login" method="post">
+        <p>
+            <label for="username">username</label><br/>
+            <input name="username" id="username" size="32" type="text" value=""/>
+            {%- if error -%}
+                <span style="color: red;">
+                    Valid usernames may only contain alphanumeric, '-', and '_' characters and be of length 3 to 10 characters long.
+                </span>
+            {%- endif -%}
+        </p>
+        <p>
+            <label for="password">password</label><br/>
+            <input name="password" id="password" size="32" type="password" value=""/>
+            {%- if error -%}
+                <span style="color: red;">
+                    Valid passwords are of a minimum length of 12 and a maximum length of 64 characters long.
+                </span>
+            {%- endif -%}
+        </p>
+        <p>
+            <input type="checkbox" name="remember" id="remember" value="y" />
+            <label for="remember">remember me</label>
+        </p>
+        <p>
+            <input name="submit" type="submit" id="submit" value="sign in"/>
+        </p>
+    </form>
+{% endblock content %}
+


### PR DESCRIPTION
Implements the UI mockups specified and generated by #5 in addition to minimal route logic necessary to actually render the mockups via the web app proper.

Here's what the templates look like.
### index/home page
![Screenshot_20200301_172243](https://user-images.githubusercontent.com/18218174/75636089-6d6f4780-5be1-11ea-9a2f-a673255e9cb6.png)

### login page
![Screenshot_20200301_172253](https://user-images.githubusercontent.com/18218174/75636090-706a3800-5be1-11ea-9fb9-4bfd12f79fe6.png)

